### PR TITLE
pin esm build version to v132

### DIFF
--- a/examples/upload-file-supabase.ts
+++ b/examples/upload-file-supabase.ts
@@ -1,5 +1,5 @@
 import nhttp, { multipart, NFile } from "../mod.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.21.0";
+import { createClient } from "https://esm.sh/v132/@supabase/supabase-js@2.21.0";
 
 const url = "https://yoururl.supabase.co";
 const api_key = "supabase_api_key";

--- a/examples/with-preact-ssr/helpers/client.ts
+++ b/examples/with-preact-ssr/helpers/client.ts
@@ -2,7 +2,7 @@ import {
   FunctionComponent as FC,
   h,
   render,
-} from "https://esm.sh/preact@10.15.0";
+} from "https://esm.sh/stable/preact@10.15.0";
 
 declare global {
   interface Window {

--- a/examples/with-preact-ssr/helpers/render-ssr.ts
+++ b/examples/with-preact-ssr/helpers/render-ssr.ts
@@ -1,4 +1,4 @@
-import { renderToString } from "https://esm.sh/preact-render-to-string@6.0.3?deps=preact@10.15.0";
+import { renderToString } from "https://esm.sh/stable/preact-render-to-string@6.0.3?deps=preact@10.15.0";
 import Helmet from "../../../lib/jsx/helmet.ts";
 import bundle from "./bundle.ts";
 import { NHttp } from "../../../mod.ts";

--- a/examples/with-preact-ssr/pages/counter.tsx
+++ b/examples/with-preact-ssr/pages/counter.tsx
@@ -4,8 +4,8 @@ import {
   Fragment,
   FunctionComponent as FC,
   h,
-} from "https://esm.sh/preact@10.15.0";
-import { useEffect, useState } from "https://esm.sh/preact@10.15.0/hooks";
+} from "https://esm.sh/stable/preact@10.15.0";
+import { useEffect, useState } from "https://esm.sh/stable/preact@10.15.0/hooks";
 import withClient from "../helpers/client.ts";
 import Helmet from "../../../lib/jsx/helmet.ts";
 

--- a/examples/with-preact-ssr/server.tsx
+++ b/examples/with-preact-ssr/server.tsx
@@ -1,5 +1,5 @@
 /* @jsx h */
-import { h } from "https://esm.sh/preact@10.15.0";
+import { h } from "https://esm.sh/stable/preact@10.15.0";
 import nhttp from "../../mod.ts";
 import Counter from "./pages/counter.tsx";
 import useRenderSSR from "./helpers/render-ssr.ts";

--- a/examples/with-react.tsx
+++ b/examples/with-react.tsx
@@ -1,7 +1,7 @@
-import React from "https://esm.sh/react@18.2.0";
+import React from "https://esm.sh/stable/react@18.2.0";
 import nhttp from "../mod.ts";
 import { FC } from "../lib/jsx.ts";
-import { renderToString } from "https://esm.sh/react-dom@18.2.0/server";
+import { renderToString } from "https://esm.sh/stable/react-dom@18.2.0/server";
 import { options, renderToHtml } from "../lib/jsx/render.ts";
 import Helmet from "../lib/jsx/helmet.ts";
 

--- a/examples/with-socket-io.ts
+++ b/examples/with-socket-io.ts
@@ -18,7 +18,7 @@ const html = `
             <button type="submit">SEND</button>
         </form>
         <script type="module" async>
-            import io from "https://esm.sh/socket.io-client@4.6.2";
+            import io from "https://esm.sh/v132/socket.io-client@4.6.2";
             const socket = io();
             window.onload = () => {
               const chat = document.getElementById("my_chat");

--- a/lib/class-validator.ts
+++ b/lib/class-validator.ts
@@ -1,10 +1,10 @@
 import {
   validateOrReject,
   ValidatorOptions,
-} from "https://esm.sh/class-validator@0.14.0";
+} from "https://esm.sh/v132/class-validator@0.14.0";
 import { Handler, HttpError, RequestEvent, TRet } from "./deps.ts";
 import { joinHandlers, TDecorator } from "./controller.ts";
-export * from "https://esm.sh/class-validator@0.14.0";
+export * from "https://esm.sh/v132/class-validator@0.14.0";
 
 type Class = { new (...args: TRet[]): TRet };
 

--- a/lib/jsx/twind.ts
+++ b/lib/jsx/twind.ts
@@ -4,9 +4,9 @@ import {
   install as installOri,
   type TwindConfig,
   TwindUserConfig,
-} from "https://esm.sh/@twind/core@1.1.3";
-import presetAutoprefix from "https://esm.sh/@twind/preset-autoprefix@1.0.7";
-import presetTailwind from "https://esm.sh/@twind/preset-tailwind@1.1.4";
+} from "https://esm.sh/v132/@twind/core@1.1.3";
+import presetAutoprefix from "https://esm.sh/v132/@twind/preset-autoprefix@1.0.7";
+import presetTailwind from "https://esm.sh/v132/@twind/preset-tailwind@1.1.4";
 import { options } from "./render.ts";
 
 /**

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,4 +1,4 @@
-import jwts from "https://esm.sh/jwt-simple@0.5.6";
+import jwts from "https://esm.sh/v132/jwt-simple@0.5.6";
 import { Handler, HttpError, RequestEvent, TRet } from "./deps.ts";
 import { NextFunction } from "../mod.ts";
 import { joinHandlers, TDecorator } from "./controller.ts";

--- a/lib/trpc.ts
+++ b/lib/trpc.ts
@@ -1,8 +1,8 @@
-import { fetchRequestHandler } from "https://esm.sh/@trpc/server@10.25.0/adapters/fetch";
+import { fetchRequestHandler } from "https://esm.sh/v132/@trpc/server@10.25.0/adapters/fetch";
 import {
   AnyRouter,
   inferRouterContext,
-} from "https://esm.sh/@trpc/server@10.25.0";
+} from "https://esm.sh/v132/@trpc/server@10.25.0";
 import { Handler, NextFunction, RequestEvent, TRet } from "./deps.ts";
 
 type TAnyRouter = TRet;

--- a/lib/zod-validator.ts
+++ b/lib/zod-validator.ts
@@ -1,4 +1,4 @@
-import { z, ZodSchema } from "https://esm.sh/zod@3.21.4";
+import { z, ZodSchema } from "https://esm.sh/v132/zod@3.21.4";
 import { joinHandlers, TDecorator } from "./controller.ts";
 import { Handler, HttpError, RequestEvent, TRet } from "./deps.ts";
 


### PR DESCRIPTION
Introduced buildversion in esm.sh deps url, to fix problem mentioned in issue https://github.com/nhttp/nhttp/issues/40

I'm not 100% sure about the special `stable` buildversion one should use for UI libraries.
This is mentioned here: https://github.com/esm-dev/esm.sh#pinning-build-version

I'm also not sure how to run build_scripts etc. but I think everything else has to happen after merge by a build server.