### PR TITLE
fix(lib/jsx): prevent XSS exploitation

### DIFF
--- a/examples/with-jsx/components/layout.tsx
+++ b/examples/with-jsx/components/layout.tsx
@@ -1,11 +1,13 @@
 /** @jsx n */
 /** @jsxFrag n.Fragment */
 
+import { JSXNode } from "../../../lib/jsx.ts";
 import { FC, n } from "../deps.ts";
 
 const Link: FC<{
   id: string;
   href: string;
+  children: string;
 }> = ({ href, id, children }) => {
   return (
     <a
@@ -20,7 +22,7 @@ const Link: FC<{
   );
 };
 
-const Layout: FC<{ id: string }> = ({ id, children }) => {
+const Layout: FC<{ id: string; children: JSXNode }> = ({ id, children }) => {
   return (
     <>
       <nav>
@@ -29,6 +31,7 @@ const Layout: FC<{ id: string }> = ({ id, children }) => {
         <Link href="/contact" id={id}>Contact</Link>
       </nav>
       <div>{children}</div>
+      <footer>Made with {"<3"} using nhttp</footer>
     </>
   );
 };

--- a/examples/with-preact-ssr/helpers/render-ssr.ts
+++ b/examples/with-preact-ssr/helpers/render-ssr.ts
@@ -17,7 +17,7 @@ export default function useRenderSSR(app: NHttp) {
         ...current,
         n("script", {
           dangerouslySetInnerHTML: {
-            __html: `window.__INIT_PROPS__=${props}`.replace(/</g, '\\u003c'),
+            __html: `window.__INIT_PROPS__=${props}`.replace(/</g, "\\u003c"),
           },
         }),
         n("script", { type: "module", src: clientPath, async: true }),

--- a/examples/with-preact-ssr/helpers/render-ssr.ts
+++ b/examples/with-preact-ssr/helpers/render-ssr.ts
@@ -1,5 +1,5 @@
 import { renderToString } from "https://esm.sh/stable/preact-render-to-string@6.0.3?deps=preact@10.15.0";
-import { Helmet } from "../../../lib/jsx.ts";
+import { Helmet, n } from "../../../lib/jsx.ts";
 import bundle from "./bundle.ts";
 import { NHttp } from "../../../mod.ts";
 import { options } from "../../../lib/jsx/render.ts";
@@ -15,8 +15,12 @@ export default function useRenderSSR(app: NHttp) {
     Helmet.writeFooterTag = () => {
       return [
         ...current,
-        `<script>window.__INIT_PROPS__=${props}</script>`,
-        `<script type="module" src="${clientPath}" async=""></script>`,
+        n("script", {
+          dangerouslySetInnerHTML: {
+            __html: `window.__INIT_PROPS__=${props}`.replace(/</g, '\\u003c'),
+          },
+        }),
+        n("script", { type: "module", src: clientPath, async: true }),
       ];
     };
     return body;

--- a/lib/jsx/helmet.ts
+++ b/lib/jsx/helmet.ts
@@ -1,4 +1,4 @@
-import { renderToString, type Attributes, type FC } from "./index.ts";
+import { type Attributes, type FC, renderToString } from "./index.ts";
 
 export type HelmetRewind = {
   head: JSX.Element[];
@@ -9,43 +9,45 @@ export type HelmetRewind = {
   };
   body?: JSX.Element;
 };
-type FCHelmet = FC<{
-  footer?: boolean;
-  children?: JSX.Element[] | JSX.Element;
-}> & {
-  /**
-   * Rewind Helmet.
-   * @example
-   * const { head, footer, body, attr } = Helmet.rewind(<App />);
-   */
-  rewind: (elem?: JSX.Element) => HelmetRewind;
-  /**
-   * Custom render.
-   */
-  render: (elem: JSX.Element) => string;
-  /**
-   * Write head tags.
-   * @example
-   * const current = Helmet.writeHeadTag?.() ?? [];
-   * Helmet.writeHeadTag = () => [
-   *   ...current,
-   *   <script src="/client.js"></script>
-   * ];
-   */
-  writeHeadTag?: () => JSX.Element[];
-  /**
-   * Write body tags.
-   * @example
-   * const current = Helmet.writeFooterTag?.() ?? [];
-   * Helmet.writeFooterTag = () => [
-   *   ...current,
-   *   <script src="/client.js"></script>
-   * ];
-   */
-  writeFooterTag?: () => JSX.Element[];
-  writeHtmlAttr?: () => Attributes;
-  writeBodyAttr?: () => Attributes;
-};
+type FCHelmet =
+  & FC<{
+    footer?: boolean;
+    children?: JSX.Element[] | JSX.Element;
+  }>
+  & {
+    /**
+     * Rewind Helmet.
+     * @example
+     * const { head, footer, body, attr } = Helmet.rewind(<App />);
+     */
+    rewind: (elem?: JSX.Element) => HelmetRewind;
+    /**
+     * Custom render.
+     */
+    render: (elem: JSX.Element) => string;
+    /**
+     * Write head tags.
+     * @example
+     * const current = Helmet.writeHeadTag?.() ?? [];
+     * Helmet.writeHeadTag = () => [
+     *   ...current,
+     *   <script src="/client.js"></script>
+     * ];
+     */
+    writeHeadTag?: () => JSX.Element[];
+    /**
+     * Write body tags.
+     * @example
+     * const current = Helmet.writeFooterTag?.() ?? [];
+     * Helmet.writeFooterTag = () => [
+     *   ...current,
+     *   <script src="/client.js"></script>
+     * ];
+     */
+    writeFooterTag?: () => JSX.Element[];
+    writeHtmlAttr?: () => Attributes;
+    writeBodyAttr?: () => Attributes;
+  };
 
 function toHelmet(elems: JSX.Element[]) {
   const helmet: JSX.Element[] = [];

--- a/lib/jsx/helmet.ts
+++ b/lib/jsx/helmet.ts
@@ -90,13 +90,13 @@ export const Helmet: FCHelmet = ({ children, footer }) => {
   for (let i = 0; i < children.length; i++) {
     const child = children[i];
     if (child.type === "html") {
-      Helmet.writeHtmlAttr = () => child.props ?? {};
+      Helmet.writeHtmlAttr = () => (child.props ?? {}) as Attributes;
     } else if (child.type === "body") {
-      Helmet.writeBodyAttr = () => child.props ?? {};
+      Helmet.writeBodyAttr = () => (child.props ?? {}) as Attributes;
     } else elements.push(child);
   }
-  if (footer) Helmet.writeFooterTag = () => toHelmet(bodys.concat(elements));
-  else Helmet.writeHeadTag = () => toHelmet(heads.concat(elements));
+  if (footer) Helmet.writeFooterTag = () => toHelmet(elements.concat(bodys));
+  else Helmet.writeHeadTag = () => toHelmet(elements.concat(heads));
   return null;
 };
 

--- a/lib/jsx/index.ts
+++ b/lib/jsx/index.ts
@@ -12,17 +12,18 @@ export type JSXNode =
 export const dangerHTML = "dangerouslySetInnerHTML";
 declare global {
   namespace JSX {
-    interface Element extends JSXElement {}
+    type Element = JSXElement;
     interface IntrinsicElements {
       [k: string]: Attributes & { children?: JSXNode };
     }
     interface ElementChildrenAttribute {
+      // deno-lint-ignore ban-types
       children: {};
     }
   }
 }
 type Fragment = null;
-export type JSXElement<T = {}> = {
+export type JSXElement<T = object> = {
   type: string | FC<T>;
   props: T | null | undefined;
 };
@@ -39,7 +40,7 @@ export type Attributes = {
  *   return <h1>{props.title}</h1>
  * }
  */
-export type FC<T = {}> = (props: T) => JSXElement | null;
+export type FC<T = object> = (props: T) => JSXElement | null;
 
 /**
  * Fragment.
@@ -55,25 +56,27 @@ export function n(
   props?: Attributes | null,
   ...children: JSXNode[]
 ): JSXElement;
-export function n<T extends {} = {}>(
+export function n<T = object>(
   type: FC<T>,
   props?: T | null,
   ...children: JSXNode[]
 ): JSXElement | null;
 export function n(
   type: Fragment,
-  props?: {} | null,
+  props?: object | null,
   ...children: JSXNode[]
 ): JSXElement;
 export function n(
   type: string | FC | null,
-  props?: {} | null,
+  props?: object | null,
   ...children: JSXNode[]
 ): JSXNode {
-  if (type === null)
-    return children
-  if (children.length > 0)
+  if (type === null) {
+    return children;
+  }
+  if (children.length > 0) {
     return { type, props: { ...props, children } };
+  }
   return { type, props };
 }
 n.Fragment = Fragment;

--- a/lib/jsx/index.ts
+++ b/lib/jsx/index.ts
@@ -22,7 +22,7 @@ declare global {
     }
   }
 }
-type Fragment = null;
+
 export type JSXElement<T = object> = {
   type: string | FC<T>;
   props: T | null | undefined;
@@ -49,7 +49,8 @@ export type FC<T = object> = (props: T) => JSXElement | null;
  *   return <Fragment><h1>{props.title}</h1></Fragment>
  * }
  */
-export const Fragment = null;
+export const Fragment: FC<{ children?: JSXNode }> = ({ children }) =>
+  children as JSXElement;
 
 export function n(
   type: string,
@@ -62,18 +63,10 @@ export function n<T = object>(
   ...children: JSXNode[]
 ): JSXElement | null;
 export function n(
-  type: Fragment,
-  props?: object | null,
-  ...children: JSXNode[]
-): JSXElement;
-export function n(
-  type: string | FC | null,
+  type: string | FC,
   props?: object | null,
   ...children: JSXNode[]
 ): JSXNode {
-  if (type === null) {
-    return children;
-  }
   if (children.length > 0) {
     return { type, props: { ...props, children } };
   }

--- a/lib/jsx/render.ts
+++ b/lib/jsx/render.ts
@@ -1,6 +1,6 @@
 import type { RequestEvent, TRet } from "../deps.ts";
 import { Helmet, type HelmetRewind } from "./helmet.ts";
-import { JSXNode, dangerHTML, n } from "./index.ts";
+import { dangerHTML, JSXNode, n } from "./index.ts";
 import { isValidElement } from "./is-valid-element.ts";
 
 export { isValidElement };
@@ -32,7 +32,10 @@ type TOptionsRender = {
    *   return str;
    * }
    */
-  onRenderElement: (elem: JSX.Element, rev: RequestEvent) => string | Promise<string>;
+  onRenderElement: (
+    elem: JSX.Element,
+    rev: RequestEvent,
+  ) => string | Promise<string>;
   /**
    * Attach on render html.
    * @example
@@ -65,7 +68,7 @@ const toStyle = (val: Record<string, string | number>) => {
       ":" +
       (typeof val[b] === "number" ? val[b] + "px" : val[b]) +
       ";",
-    ""
+    "",
   );
 };
 
@@ -97,8 +100,9 @@ export const renderToString = (elem: JSXNode): string => {
       k === dangerHTML ||
       k === "children" ||
       typeof val === "function"
-    )
+    ) {
       continue;
+    }
 
     const key = k === "className" ? "class" : kebab(k);
 
@@ -111,12 +115,16 @@ export const renderToString = (elem: JSXNode): string => {
     }
   }
 
-  if (type in voidTags)
+  if (type in voidTags) {
     return `<${type}${attributes}>`;
-  if (props?.[dangerHTML] != null)
+  }
+  if (props?.[dangerHTML] != null) {
     return `<${type}${attributes}>${props[dangerHTML].__html}</${type}>`;
+  }
 
-  return `<${type}${attributes}>${renderToString(props?.["children"])}</${type}>`;
+  return `<${type}${attributes}>${
+    renderToString(props?.["children"])
+  }</${type}>`;
 };
 export const options: TOptionsRender = {
   onRenderHtml: (html) => html,
@@ -143,7 +151,7 @@ const toHtml = (body: string, { head, footer, attr }: HelmetRewind) => {
           ...attr.body,
           dangerouslySetInnerHTML: { __html: bodyWithFooter },
         }),
-      ])
+      ]),
     )
   );
 };


### PR DESCRIPTION
I gave a go at fixing the XSS issue. JSX / TSX components now generate virtual nodes, which are only rendered to a string when needed.

I had to rewrite parts of the Helmet implementation. As a side effect, tags are no longer de-duped (except for the `<title>` and `<base>` tags), since comparing e.g. `<link>` elements can no longer be trivially done. Is that a dealbreaker though?

Fixes #59