### PR TITLE
feat(lib/jsx): support for jsx transform precompile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ dev.ts
 dev.js
 dev.tsx
 bench.ts
+bench.tsx
 dev.tsx
 deno.lock
 note.txt

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Simple web-framework for <a href="https://deno.land/">Deno</a> and Friends.
    <a href="https://codecov.io/gh/nhttp/nhttp"><img src="https://codecov.io/gh/nhttp/nhttp/branch/master/graph/badge.svg?token=SJ2NZQ0ZJG" alt="coverage" /></a>
    <a href="https://www.codefactor.io/repository/github/nhttp/nhttp/overview/master"><img src="https://www.codefactor.io/repository/github/nhttp/nhttp/badge/master" alt="codefactor" /></a>
    <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2Fnhttp%2Fmod.ts" alt="denoland" /></a>
-   <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fhttps%2Fdeno.land%2Fx%2Fnhttp@1.3.14%2Fmod.ts" alt="deps" /></a>
+   <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fhttps%2Fdeno.land%2Fx%2Fnhttp@1.3.15%2Fmod.ts" alt="deps" /></a>
    <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/bundlephobia/minzip/nhttp-land" alt="size" /></a>
    <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/bundlephobia/min/nhttp-land" alt="size" /></a>
    <a href="http://badges.mit-license.org"><img src="https://img.shields.io/:license-mit-blue.svg" alt="licence" /></a>

--- a/egg.json
+++ b/egg.json
@@ -5,7 +5,7 @@
   "stable": true,
   "description": "An Simple web-framework for Deno and Friends",
   "homepage": "https://github.com/nhttp/nhttp",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "files": [
     "deno.json",
     "./mod.js",

--- a/lib/jsx/index.ts
+++ b/lib/jsx/index.ts
@@ -104,7 +104,6 @@ export const Client: FC<{
   src: string;
   id?: string;
   type?: string;
-  children?: JSXNode;
 }> = (props) => {
   return n(Fragment, {}, [
     n(

--- a/lib/jsx/is-valid-element.ts
+++ b/lib/jsx/is-valid-element.ts
@@ -1,4 +1,5 @@
 import { TRet } from "../deps.ts";
+import { options } from "./index.ts";
 
 /**
  * isValidElement.
@@ -10,6 +11,9 @@ export const isValidElement = (elem: TRet) => {
     if (typeof elem.type === "function") return true;
     const has = (k: string) => Object.hasOwn(elem, k);
     if (has("type") && has("props") && has("key")) return true;
+  }
+  if (options.precompile && typeof elem === "string" && elem[0] === "<") {
+    return true;
   }
   return false;
 };

--- a/lib/jsx/is-valid-element.ts
+++ b/lib/jsx/is-valid-element.ts
@@ -12,7 +12,9 @@ export const isValidElement = (elem: TRet) => {
     const has = (k: string) => Object.hasOwn(elem, k);
     if (has("type") && has("props") && has("key")) return true;
   }
-  if (options.precompile && typeof elem === "string" && elem[0] === "<") {
+  if (
+    options.precompile && typeof elem === "string" && elem[0] === "<"
+  ) {
     return true;
   }
   return false;

--- a/lib/jsx/jsx-runtime.ts
+++ b/lib/jsx/jsx-runtime.ts
@@ -33,7 +33,7 @@ export { createElement as jsxDEV };
 export const jsxTemplate = (tpl: TemplateStringsArray, ...subs: JSXNode[]) => {
   options.precompile ??= true;
   return tpl.reduce((prev, cur, i) => {
-    return prev + renderToString(subs[i - 1] as JSXNode) + cur;
+    return prev + renderToString(subs[i - 1]) + cur;
   });
 };
 export const jsxEscape = (

--- a/lib/jsx/jsx-runtime.ts
+++ b/lib/jsx/jsx-runtime.ts
@@ -36,7 +36,11 @@ export const jsxTemplate = (tpl: TemplateStringsArray, ...subs: JSXNode[]) => {
     return prev + renderToString(subs[i - 1] as JSXNode) + cur;
   });
 };
-export const jsxEscape = (v: unknown) => v;
+export const jsxEscape = (
+  v: string | null | JSXNode | Array<string | null | JSXNode>,
+) => {
+  return typeof v === "boolean" || typeof v === "function" ? null : v;
+};
 export const jsxAttr = (k: string, v: unknown) => {
   if (k === "style" && typeof v === "object") {
     return `${k}="${toStyle(v as Record<string, string | number>)}"`;
@@ -49,5 +53,5 @@ export const jsxAttr = (k: string, v: unknown) => {
   ) {
     return "";
   } else if (v === true) return k;
-  return k + '="' + escapeHtml(v as string, true) + '"';
+  return `${k}="${escapeHtml(v as string, true)}"`;
 };

--- a/lib/jsx/jsx-runtime.ts
+++ b/lib/jsx/jsx-runtime.ts
@@ -39,7 +39,9 @@ export const jsxTemplate = (tpl: TemplateStringsArray, ...subs: JSXNode[]) => {
 export const jsxEscape = (
   v: string | null | JSXNode | Array<string | null | JSXNode>,
 ) => {
-  return typeof v === "boolean" || typeof v === "function" ? null : v;
+  return v == null || typeof v === "boolean" || typeof v === "function"
+    ? null
+    : v;
 };
 export const jsxAttr = (k: string, v: unknown) => {
   if (k === "style" && typeof v === "object") {

--- a/lib/jsx/render.ts
+++ b/lib/jsx/render.ts
@@ -44,10 +44,14 @@ type TOptionsRender = {
    * }
    */
   onRenderHtml: (html: string, rev: RequestEvent) => string | Promise<string>;
+  /**
+   * jsx transform precompile.
+   */
+  precompile?: boolean;
 };
-
-function escapeHtml(unsafe: string) {
-  return unsafe
+const REG_HTML = /["'&<>]/;
+export function escapeHtml(str: string, force = false): string {
+  return !REG_HTML.test(str) || (options.precompile && !force) ? str : str
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
@@ -59,7 +63,7 @@ function kebab(camelCase: string) {
   return camelCase.replace(/[A-Z]/g, "-$&").toLowerCase();
 }
 
-const toStyle = (val: Record<string, string | number>) => {
+export const toStyle = (val: Record<string, string | number>) => {
   return Object.keys(val).reduce(
     (a, b) =>
       a +

--- a/npm/README.md
+++ b/npm/README.md
@@ -12,7 +12,7 @@ An Simple web-framework for <a href="https://deno.land/">Deno</a> and Friends.
    <a href="https://codecov.io/gh/nhttp/nhttp"><img src="https://codecov.io/gh/nhttp/nhttp/branch/master/graph/badge.svg?token=SJ2NZQ0ZJG" alt="coverage" /></a>
    <a href="https://www.codefactor.io/repository/github/nhttp/nhttp/overview/master"><img src="https://www.codefactor.io/repository/github/nhttp/nhttp/badge/master" alt="codefactor" /></a>
    <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2Fnhttp%2Fmod.ts" alt="denoland" /></a>
-   <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fhttps%2Fdeno.land%2Fx%2Fnhttp@1.3.14%2Fmod.ts" alt="deps" /></a>
+   <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fhttps%2Fdeno.land%2Fx%2Fnhttp@1.3.15%2Fmod.ts" alt="deps" /></a>
    <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/bundlephobia/minzip/nhttp-land" alt="size" /></a>
    <a href="https://deno.land/x/nhttp"><img src="https://img.shields.io/bundlephobia/min/nhttp-land" alt="size" /></a>
    <a href="http://badges.mit-license.org"><img src="https://img.shields.io/:license-mit-blue.svg" alt="licence" /></a>

--- a/npm/dist/cjs/lib/csrf.js
+++ b/npm/dist/cjs/lib/csrf.js
@@ -31,9 +31,9 @@ __export(csrf_exports, {
   default: () => csrf_default
 });
 module.exports = __toCommonJS(csrf_exports);
-var import_node_crypto = __toESM(require("node:crypto"), 1);
+var import_node_crypto = __toESM(require("node:crypto"));
 var import_deps = require("./deps");
-const rand = () => `${Date.now().toString(36)}${Math.random().toString(36).slice(5)}`.replace(".", "");
+const rand = () => `${performance.now().toString(36)}${Math.random().toString(36).slice(5)}`.replace(".", "");
 const CHARS = [
   "A",
   "B",
@@ -104,6 +104,7 @@ const csrf = (opts = {}) => {
     opts.secret ??= rand();
   const cname = "__csrf__";
   const ignoreMethods = opts.ignoreMethods ?? ["GET", "HEAD", "OPTIONS", "TRACE"];
+  const algo = opts.algo ?? "SHA1";
   return (rev, next) => {
     rev.csrfToken = () => {
       let secret = opts.secret ?? rand();
@@ -116,18 +117,18 @@ const csrf = (opts = {}) => {
           typeof cookie === "object" ? cookie : void 0
         );
       }
-      return create(secret, opts.salt ?? 8);
+      return create(secret, opts.salt ?? 8, algo);
     };
     rev.csrfVerify = () => {
-      if (ignoreMethods.includes(rev.method)) {
+      if (ignoreMethods.includes(rev.method))
         return true;
-      }
       const value = opts.getValue?.(rev) ?? getDefaultValue(rev);
       if (value == null)
         return true;
       return verify(
         cookie ? rev.cookies[cname] : opts.secret,
-        value
+        value,
+        algo
       );
     };
     if (autoVerify) {
@@ -140,18 +141,18 @@ const csrf = (opts = {}) => {
     return next();
   };
 };
-function toHash(str) {
-  return import_node_crypto.default.createHash("sha1").update(str, "utf8").digest("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+function toHash(str, algo) {
+  return import_node_crypto.default.createHash(algo).update(str, "utf8").digest("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
-function create(secret, saltLen) {
+function create(secret, saltLen, algo) {
   const salt = new Array(saltLen).fill(void 0).map(() => CHARS[Math.random() * CHARS.length | 0]).join("");
-  return `${salt}-${toHash(`${salt}-${secret}`)}`;
+  return `${salt}-${toHash(`${salt}-${secret}`, algo)}`;
 }
-function verify(secret, token) {
+function verify(secret, token, algo) {
   if (!~token.indexOf("-"))
     return false;
   const salt = token.substring(0, token.indexOf("-"));
-  const expected = `${salt}-${toHash(`${salt}-${secret}`)}`;
+  const expected = `${salt}-${toHash(`${salt}-${secret}`, algo)}`;
   return expected === token;
 }
 function getDefaultValue(rev) {

--- a/npm/dist/cjs/lib/jsx/is-valid-element.js
+++ b/npm/dist/cjs/lib/jsx/is-valid-element.js
@@ -20,6 +20,7 @@ __export(is_valid_element_exports, {
   isValidElement: () => isValidElement
 });
 module.exports = __toCommonJS(is_valid_element_exports);
+var import_index = require("./index");
 const isValidElement = (elem) => {
   if (typeof elem === "object") {
     if (typeof elem.type === "function")
@@ -27,6 +28,9 @@ const isValidElement = (elem) => {
     const has = (k) => Object.hasOwn(elem, k);
     if (has("type") && has("props") && has("key"))
       return true;
+  }
+  if (import_index.options.precompile && typeof elem === "string" && elem[0] === "<") {
+    return true;
   }
   return false;
 };

--- a/npm/dist/cjs/lib/jsx/jsx-runtime.js
+++ b/npm/dist/cjs/lib/jsx/jsx-runtime.js
@@ -19,24 +19,52 @@ var jsx_runtime_exports = {};
 __export(jsx_runtime_exports, {
   Fragment: () => import_index.Fragment,
   jsx: () => createElement,
+  jsxAttr: () => jsxAttr,
   jsxDEV: () => createElement,
   jsxDev: () => createElement,
+  jsxEscape: () => jsxEscape,
+  jsxTemplate: () => jsxTemplate,
   jsxs: () => createElement
 });
 module.exports = __toCommonJS(jsx_runtime_exports);
 var import_index = require("./index");
+const isArray = Array.isArray;
 const createElement = (type, props) => {
-  const hasChild = props.children != null;
-  const children = hasChild ? props.children : [];
-  if (hasChild)
-    delete props.children;
-  return (0, import_index.n)(type, props, ...children.pop ? children : [children]);
+  if (props?.children == null)
+    return (0, import_index.n)(type, props);
+  const childs = props.children;
+  delete props.children;
+  if (isArray(childs))
+    return (0, import_index.n)(type, props, ...childs);
+  return (0, import_index.n)(type, props, childs);
+};
+const jsxTemplate = (tpl, ...subs) => {
+  import_index.options.precompile ??= true;
+  return tpl.reduce((prev, cur, i) => {
+    return prev + (0, import_index.renderToString)(subs[i - 1]) + cur;
+  });
+};
+const jsxEscape = (v) => {
+  return v == null || typeof v === "boolean" || typeof v === "function" ? null : v;
+};
+const jsxAttr = (k, v) => {
+  if (k === "style" && typeof v === "object") {
+    return `${k}="${(0, import_index.toStyle)(v)}"`;
+  }
+  if (v == null || v === false || typeof v === "function" || typeof v === "object") {
+    return "";
+  } else if (v === true)
+    return k;
+  return `${k}="${(0, import_index.escapeHtml)(v, true)}"`;
 };
 // Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = {
   Fragment,
   jsx,
+  jsxAttr,
   jsxDEV,
   jsxDev,
+  jsxEscape,
+  jsxTemplate,
   jsxs
 });

--- a/npm/dist/cjs/lib/jsx/twind.js
+++ b/npm/dist/cjs/lib/jsx/twind.js
@@ -33,8 +33,8 @@ __export(twind_exports, {
 });
 module.exports = __toCommonJS(twind_exports);
 var import_core = require("@twind/core");
-var import_preset_autoprefix = __toESM(require("@twind/preset-autoprefix"), 1);
-var import_preset_tailwind = __toESM(require("@twind/preset-tailwind"), 1);
+var import_preset_autoprefix = __toESM(require("@twind/preset-autoprefix"));
+var import_preset_tailwind = __toESM(require("@twind/preset-tailwind"));
 var import_render = require("./render");
 const install = (config = {}, isProduction) => {
   return (0, import_core.install)({

--- a/npm/dist/cjs/lib/jwt.js
+++ b/npm/dist/cjs/lib/jwt.js
@@ -32,7 +32,7 @@ __export(jwt_exports, {
   jwt: () => jwt
 });
 module.exports = __toCommonJS(jwt_exports);
-var import_jwt_simple = __toESM(require("jwt-simple"), 1);
+var import_jwt_simple = __toESM(require("jwt-simple"));
 var import_deps = require("./deps");
 var import_controller = require("./controller");
 class UnauthorizedError extends import_deps.HttpError {

--- a/npm/dist/esm/lib/jsx/is-valid-element.js
+++ b/npm/dist/esm/lib/jsx/is-valid-element.js
@@ -1,3 +1,4 @@
+import { options } from "./index.js";
 const isValidElement = (elem) => {
   if (typeof elem === "object") {
     if (typeof elem.type === "function")
@@ -5,6 +6,9 @@ const isValidElement = (elem) => {
     const has = (k) => Object.hasOwn(elem, k);
     if (has("type") && has("props") && has("key"))
       return true;
+  }
+  if (options.precompile && typeof elem === "string" && elem[0] === "<") {
+    return true;
   }
   return false;
 };

--- a/npm/dist/esm/lib/jsx/jsx-runtime.js
+++ b/npm/dist/esm/lib/jsx/jsx-runtime.js
@@ -1,15 +1,47 @@
-import { Fragment, n } from "./index.js";
+import {
+  escapeHtml,
+  Fragment,
+  n,
+  options,
+  renderToString,
+  toStyle
+} from "./index.js";
+const isArray = Array.isArray;
 const createElement = (type, props) => {
-  const hasChild = props.children != null;
-  const children = hasChild ? props.children : [];
-  if (hasChild)
-    delete props.children;
-  return n(type, props, ...children.pop ? children : [children]);
+  if (props?.children == null)
+    return n(type, props);
+  const childs = props.children;
+  delete props.children;
+  if (isArray(childs))
+    return n(type, props, ...childs);
+  return n(type, props, childs);
+};
+const jsxTemplate = (tpl, ...subs) => {
+  options.precompile ??= true;
+  return tpl.reduce((prev, cur, i) => {
+    return prev + renderToString(subs[i - 1]) + cur;
+  });
+};
+const jsxEscape = (v) => {
+  return v == null || typeof v === "boolean" || typeof v === "function" ? null : v;
+};
+const jsxAttr = (k, v) => {
+  if (k === "style" && typeof v === "object") {
+    return `${k}="${toStyle(v)}"`;
+  }
+  if (v == null || v === false || typeof v === "function" || typeof v === "object") {
+    return "";
+  } else if (v === true)
+    return k;
+  return `${k}="${escapeHtml(v, true)}"`;
 };
 export {
   Fragment,
   createElement as jsx,
+  jsxAttr,
   createElement as jsxDEV,
   createElement as jsxDev,
+  jsxEscape,
+  jsxTemplate,
   createElement as jsxs
 };

--- a/npm/dist/esm/lib/jsx/render.js
+++ b/npm/dist/esm/lib/jsx/render.js
@@ -17,8 +17,39 @@ const voidTags = Object.assign(/* @__PURE__ */ Object.create(null), {
   track: true,
   wbr: true
 });
-function escapeHtml(unsafe) {
-  return unsafe.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+const REG_HTML = /["'&<>]/;
+function escapeHtml(str, force) {
+  return options.precompile && !force || !REG_HTML.test(str) ? str : (() => {
+    let esc = "", i = 0, l = 0, html = "";
+    for (; i < str.length; i++) {
+      switch (str.charCodeAt(i)) {
+        case 34:
+          esc = "&quot;";
+          break;
+        case 38:
+          esc = "&amp;";
+          break;
+        case 39:
+          esc = "&#39;";
+          break;
+        case 60:
+          esc = "&lt;";
+          break;
+        case 62:
+          esc = "&gt;";
+          break;
+        default:
+          continue;
+      }
+      if (i !== l)
+        html += str.substring(l, i);
+      html += esc;
+      l = i + 1;
+    }
+    if (i !== l)
+      html += str.substring(l, i);
+    return html;
+  })();
 }
 function kebab(camelCase) {
   return camelCase.replace(/[A-Z]/g, "-$&").toLowerCase();
@@ -39,16 +70,15 @@ const renderToString = (elem) => {
   if (Array.isArray(elem))
     return elem.map(renderToString).join("");
   const { type, props } = elem;
-  if (typeof type === "function") {
+  if (typeof type === "function")
     return renderToString(type(props ?? {}));
-  }
   let attributes = "";
   for (const k in props) {
     let val = props[k];
     if (val == null || val === false || k === dangerHTML || k === "children" || typeof val === "function") {
       continue;
     }
-    const key = k === "className" ? "class" : kebab(k);
+    const key = k === "className" ? "class" : k.toLowerCase();
     if (val === true) {
       attributes += ` ${key}`;
     } else {
@@ -99,8 +129,10 @@ const renderToHtml = (elem, rev) => {
 };
 renderToHtml.check = isValidElement;
 export {
+  escapeHtml,
   isValidElement,
   options,
   renderToHtml,
-  renderToString
+  renderToString,
+  toStyle
 };

--- a/npm/dist/types/lib/csrf.d.ts
+++ b/npm/dist/types/lib/csrf.d.ts
@@ -1,5 +1,5 @@
 import { type Cookie, type Handler, type RequestEvent, type TRet } from "./deps";
-type Options = {
+export type CSRFOptions = {
     /**
      * cookie. default to `false`.
      */
@@ -28,6 +28,10 @@ type Options = {
      * auto verify csrf. default to `true`.
      */
     autoVerify?: boolean;
+    /**
+     * algorithm when creating CSRF. default to `SHA1`.
+     */
+    algo?: "MD5" | "SHA" | "SHA1" | "SHA256" | "SHA512";
 };
 /**
  * Cross-Site Request Forgery (CSRF) protected middleware.
@@ -52,5 +56,5 @@ type Options = {
  *   return <MyForm csrf={rev.csrfToken()}/>
  * });
  */
-export declare const csrf: (opts?: Options) => Handler;
+export declare const csrf: (opts?: CSRFOptions) => Handler;
 export default csrf;

--- a/npm/dist/types/lib/jsx/index.d.ts
+++ b/npm/dist/types/lib/jsx/index.d.ts
@@ -72,5 +72,4 @@ export declare const Client: FC<{
     src: string;
     id?: string;
     type?: string;
-    children?: JSXNode;
 }>;

--- a/npm/dist/types/lib/jsx/jsx-runtime.d.ts
+++ b/npm/dist/types/lib/jsx/jsx-runtime.d.ts
@@ -1,9 +1,13 @@
-import { Fragment } from "./index";
-type TRet = any;
-type CrateElement = (type: TRet, props: TRet, ...args: TRet) => TRet;
-declare const createElement: CrateElement;
+import { type Attributes, Fragment, type JSXElement, type JSXNode } from "./index";
+type CreateElement = (type: string, props?: Attributes & {
+    children?: JSXElement | JSXElement[];
+}, ...args: unknown[]) => JSXNode;
+declare const createElement: CreateElement;
 export { Fragment };
 export { createElement as jsx };
 export { createElement as jsxs };
 export { createElement as jsxDev };
 export { createElement as jsxDEV };
+export declare const jsxTemplate: (tpl: TemplateStringsArray, ...subs: JSXNode[]) => string;
+export declare const jsxEscape: (v: string | null | JSXNode | Array<string | null | JSXNode>) => string | number | JSXNode<{}>[] | JSXElement<{}>;
+export declare const jsxAttr: (k: string, v: unknown) => string;

--- a/npm/dist/types/lib/jsx/render.d.ts
+++ b/npm/dist/types/lib/jsx/render.d.ts
@@ -21,7 +21,13 @@ type TOptionsRender = {
      * }
      */
     onRenderHtml: (html: string, rev: RequestEvent) => string | Promise<string>;
+    /**
+     * jsx transform precompile.
+     */
+    precompile?: boolean;
 };
+export declare function escapeHtml(str: string, force?: boolean): string;
+export declare const toStyle: (val: Record<string, string | number>) => string;
 /**
  * renderToString.
  * @example

--- a/npm/package.json
+++ b/npm/package.json
@@ -2,7 +2,7 @@
   "name": "nhttp-land",
   "description": "An Simple web-framework for Deno and Friends",
   "author": "Herudi",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",

--- a/scripts/build_npm.ts
+++ b/scripts/build_npm.ts
@@ -129,7 +129,7 @@ const pkg = {
   "name": "nhttp-land",
   "description": "An Simple web-framework for Deno and Friends",
   "author": "Herudi",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "module": "./dist/esm/index.js",
   "main": "./dist/cjs/index.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
this PR, support for jsx transform `precompile`. Deno has claimed 7 ~ 20x faster.
ref => [fastest jsx transform](https://deno.com/blog/v1.38#fastest-jsx-transform)

config deno.json
```json
{
  "compilerOptions": {
    "jsx": "precompile",
    "jsxImportSource": "nhttp-jsx"
  },
  "imports": {
    "nhttp-jsx/jsx-runtime": "https://deno.land/x/nhttp@1.3.15/lib/jsx/jsx-runtime.ts"
  }
}
```  