### PR TITLE
handle swagger special regex replacement $-references

### DIFF
--- a/ext/tailwind/mod.ts
+++ b/ext/tailwind/mod.ts
@@ -193,7 +193,7 @@ export const tailwind = async (
         new Response(
           text.replace(
             "</head>",
-            `<link rel="stylesheet" href="${path}"></head>`,
+            () => `<link rel="stylesheet" href="${path}"></head>`,
           ),
           {
             headers: clone.headers,

--- a/lib/swagger/swagger_ui.ts
+++ b/lib/swagger/swagger_ui.ts
@@ -162,18 +162,18 @@ const generateHTML = (
     : favIconHtml;
   const htmlWithCustomCss = _htmlTplString
     .toString()
-    .replace("<% customCss %>", customCss);
+    .replace("<% customCss %>", () => customCss);
   const htmlWithFavIcon = htmlWithCustomCss.replace(
     "<% favIconString %>",
-    favIconString,
+    () => favIconString,
   );
   const htmlWithCustomJs = htmlWithFavIcon.replace(
     "<% customJs %>",
-    customJs ? `<script src="${customJs}"></script>` : "",
+    () => customJs ? `<script src="${customJs}"></script>` : "",
   );
   const htmlWithCustomCssUrl = htmlWithCustomJs.replace(
     "<% customCssUrl %>",
-    customCssUrl ? `<link href="${customCssUrl}" rel="stylesheet">` : "",
+    () => customCssUrl ? `<link href="${customCssUrl}" rel="stylesheet">` : "",
   );
 
   const initOptions = {
@@ -184,8 +184,8 @@ const generateHTML = (
   };
   swaggerInit = _jsTplString
     .toString()
-    .replace("<% swaggerOptions %>", stringify(initOptions));
-  return htmlWithCustomCssUrl.replace("<% title %>", customSiteTitle);
+    .replace("<% swaggerOptions %>", () => stringify(initOptions));
+  return htmlWithCustomCssUrl.replace("<% title %>", () => customSiteTitle);
 };
 /**
  * setup swagger UI.
@@ -194,13 +194,13 @@ const setup = (swaggerDoc: TObject, opts: GenHtmlOpts = {}): Handler => {
   let html = generateHTML(swaggerDoc, opts);
   html = html.replaceAll(
     "<% url_lib_swagger %>",
-    opts.baseUrlLibSwagger ? opts.baseUrlLibSwagger : base_lib_swagger,
+    () => opts.baseUrlLibSwagger || base_lib_swagger,
   );
 
   return ({ response, path }) => {
-    const relativeHtml = html.replaceAll(
+    const relativeHtml = html.replace(
       "<% base %>",
-      path.replace(/\/+$/, ""),
+      () => path.replace(/\/+$/, ""),
     );
     response.type("html");
     return relativeHtml;

--- a/lib/tailwind.ts
+++ b/lib/tailwind.ts
@@ -195,7 +195,7 @@ export const tailwind = async (
         new Response(
           text.replace(
             "</head>",
-            `<link rel="stylesheet" href="${path}"></head>`,
+            () => `<link rel="stylesheet" href="${path}"></head>`,
           ),
           {
             headers: clone.headers,


### PR DESCRIPTION
caused by
```js
{ example: { regex: "new RegExp(`${pattern}$`" } }
```
because
`_jsTplString.replace("<% swaggerOptions %>", stringify(initOptions));`
would process replacement string further and replace special regex-references
```
$1, $`, $', ...
```
e.g.
```js
"prefix <% swaggerOptions %> postfix".replace("<% swaggerOptions %>", '$`')
// => prefix prefix  postfix
"prefix <% swaggerOptions %> postfix".replace("<% swaggerOptions %>", () => '$`')
// => prefix $` postfix
```

thus resulted in, which is a syntax error, in /swagger-ui-init.js

```js
window.onload = function() {
  // Build a system
  var url = window.location.search.match(/url=([^&]+)/);
  if (url && url.length > 1) {
    url = decodeURIComponent(url[1]);
  } else {
    url = window.location.origin;
  }
  var options = { example: { regex: "new RegExp(`${pattern}
window.onload = function() {
  // Build a system
  var url = window.location.search.match(/url=([^&]+)/);
  if (url && url.length > 1) {
    url = decodeURIComponent(url[1]);
  } else {
    url = window.location.origin;
  }
  " } };
  url = options.swaggerUrl || url
```

checked (or changed) that all replace's are non-global, so each callback is called only for one single result.
this means no replacement-value has to be (heavily) re-calculated multiple times.

@herudi not sure about the two tailwind ones, changed them too as they stay functionally equal to before.